### PR TITLE
fix: backticks placement issue with `use-github-autolink` disabled

### DIFF
--- a/src/footer.ts
+++ b/src/footer.ts
@@ -70,7 +70,7 @@ export async function generateFooter(previousTagName?: string): Promise<string> 
   if (includeCompareLink() && previousTagName) {
     let link = `${ url }/compare/${ previousTagName }...${ tagName }`;
 
-    if (!useGitHubAutolink() || releaseNamePrefix()) link = `\`[${ previousTagName }...${ tagName }](${ url }/compare/${ previousTagName }...${ tagName })\``;
+    if (!useGitHubAutolink() || releaseNamePrefix()) link = `[${ previousTagName }...${ tagName }](${ url }/compare/${ previousTagName }...${ tagName })`;
 
     footer.push(`**Full Changelog**: ${ link }`);
   }

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -70,7 +70,7 @@ export async function generateFooter(previousTagName?: string): Promise<string> 
   if (includeCompareLink() && previousTagName) {
     let link = `${ url }/compare/${ previousTagName }...${ tagName }`;
 
-    if (!useGitHubAutolink() || releaseNamePrefix()) link = `[${ previousTagName }...${ tagName }](${ url }/compare/${ previousTagName }...${ tagName })`;
+    if (!useGitHubAutolink() || releaseNamePrefix()) link = `[\`${ previousTagName }...${ tagName }\`](${ url }/compare/${ previousTagName }...${ tagName })`;
 
     footer.push(`**Full Changelog**: ${ link }`);
   }

--- a/src/nodes/commit-hash.ts
+++ b/src/nodes/commit-hash.ts
@@ -59,7 +59,7 @@ export class CommitHashNode extends Node {
     if (shouldUseGithubAutolink) return sha;
 
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    return `[${ sha.slice(0, 7) }](${ repo.url }/commit/${ sha })`;
+    return `[\`${ sha.slice(0, 7) }\`](${ repo.url }/commit/${ sha })`;
   }
 
 }

--- a/src/nodes/commit-hash.ts
+++ b/src/nodes/commit-hash.ts
@@ -59,7 +59,7 @@ export class CommitHashNode extends Node {
     if (shouldUseGithubAutolink) return sha;
 
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    return `\`[${ sha.slice(0, 7) }](${ repo.url }/commit/${ sha })\``;
+    return `[${ sha.slice(0, 7) }](${ repo.url }/commit/${ sha })`;
   }
 
 }

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -138,7 +138,7 @@ it("should generate the changelog footer with the full changelog link", async ()
 
   const result = await generateFooter(info.previous.name);
 
-  expect(result).toEqual(`\n\n**Full Changelog**: \`[${ info.previous.name }...${ releaseNameInputValue }](${ url }/compare/${ info.previous.name }...${ releaseNameInputValue })\``);
+  expect(result).toEqual(`\n\n**Full Changelog**: [${ info.previous.name }...${ releaseNameInputValue }](${ url }/compare/${ info.previous.name }...${ releaseNameInputValue })`);
 
   expect(getInput).toHaveBeenCalledTimes(1);
 

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -138,7 +138,7 @@ it("should generate the changelog footer with the full changelog link", async ()
 
   const result = await generateFooter(info.previous.name);
 
-  expect(result).toEqual(`\n\n**Full Changelog**: [${ info.previous.name }...${ releaseNameInputValue }](${ url }/compare/${ info.previous.name }...${ releaseNameInputValue })`);
+  expect(result).toEqual(`\n\n**Full Changelog**: [\`${ info.previous.name }...${ releaseNameInputValue }\`](${ url }/compare/${ info.previous.name }...${ releaseNameInputValue })`);
 
   expect(getInput).toHaveBeenCalledTimes(1);
 

--- a/tests/nodes/commit-hash.test.ts
+++ b/tests/nodes/commit-hash.test.ts
@@ -84,5 +84,5 @@ it("should print the sha with the link (not using autolink)", () => {
   expect(commitHashNode.shouldUseGithubAutolink).toBe(false);
 
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-  expect(commitHashNode.print()).toBe(`\`[${ sha.slice(0, 7) }](${ context.serverUrl }/${ repo.owner }/${ repo.repo }/commit/${ sha })\``);
+  expect(commitHashNode.print()).toBe(`[${ sha.slice(0, 7) }](${ context.serverUrl }/${ repo.owner }/${ repo.repo }/commit/${ sha })`);
 });

--- a/tests/nodes/commit-hash.test.ts
+++ b/tests/nodes/commit-hash.test.ts
@@ -84,5 +84,5 @@ it("should print the sha with the link (not using autolink)", () => {
   expect(commitHashNode.shouldUseGithubAutolink).toBe(false);
 
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-  expect(commitHashNode.print()).toBe(`[${ sha.slice(0, 7) }](${ context.serverUrl }/${ repo.owner }/${ repo.repo }/commit/${ sha })`);
+  expect(commitHashNode.print()).toBe(`[\`${ sha.slice(0, 7) }\`](${ context.serverUrl }/${ repo.owner }/${ repo.repo }/commit/${ sha })`);
 });


### PR DESCRIPTION
Fixes an issue where some links would be quoted in backticks causing them to be rendered as code instead of markdown links.

Closes #220.