### PR TITLE
fix: generating broken markdown

### DIFF
--- a/src/footer.ts
+++ b/src/footer.ts
@@ -70,7 +70,7 @@ export async function generateFooter(previousTagName?: string): Promise<string> 
   if (includeCompareLink() && previousTagName) {
     let link = `${ url }/compare/${ previousTagName }...${ tagName }`;
 
-    if (!useGitHubAutolink() || releaseNamePrefix()) link = `[\`${ previousTagName }...${ tagName }\`](${ url }/compare/${ previousTagName }...${ tagName })`;
+    if (!useGitHubAutolink() || releaseNamePrefix()) link = `[${ previousTagName }...${ tagName }](${ url }/compare/${ previousTagName }...${ tagName })`;
 
     footer.push(`**Full Changelog**: ${ link }`);
   }

--- a/src/nodes/commit-hash.ts
+++ b/src/nodes/commit-hash.ts
@@ -59,7 +59,7 @@ export class CommitHashNode extends Node {
     if (shouldUseGithubAutolink) return sha;
 
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    return `[\`${ sha.slice(0, 7) }\`](${ repo.url }/commit/${ sha })`;
+    return `[${ sha.slice(0, 7) }](${ repo.url }/commit/${ sha })`;
   }
 
 }

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -138,7 +138,7 @@ it("should generate the changelog footer with the full changelog link", async ()
 
   const result = await generateFooter(info.previous.name);
 
-  expect(result).toEqual(`\n\n**Full Changelog**: [\`${ info.previous.name }...${ releaseNameInputValue }\`](${ url }/compare/${ info.previous.name }...${ releaseNameInputValue })`);
+  expect(result).toEqual(`\n\n**Full Changelog**: [${ info.previous.name }...${ releaseNameInputValue }](${ url }/compare/${ info.previous.name }...${ releaseNameInputValue })`);
 
   expect(getInput).toHaveBeenCalledTimes(1);
 

--- a/tests/nodes/commit-hash.test.ts
+++ b/tests/nodes/commit-hash.test.ts
@@ -84,5 +84,5 @@ it("should print the sha with the link (not using autolink)", () => {
   expect(commitHashNode.shouldUseGithubAutolink).toBe(false);
 
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-  expect(commitHashNode.print()).toBe(`[\`${ sha.slice(0, 7) }\`](${ context.serverUrl }/${ repo.owner }/${ repo.repo }/commit/${ sha })`);
+  expect(commitHashNode.print()).toBe(`[${ sha.slice(0, 7) }](${ context.serverUrl }/${ repo.owner }/${ repo.repo }/commit/${ sha })`);
 });


### PR DESCRIPTION
With `use-github-autolink` set to `false`, I expect the changelog only to contain valid Markdown. This is a follow-up PR to the one I made here #221, which still generates bad markdown.

**Problem:**
When we create the markdown links we try to put backticks \` around the text to make it look like code. No markdown renderer I know of, however, supports this! Inline or not, code blocks cannot be clickable links.

**Fix:**
This will result in a working link:
\[TEXT\](LINK)

This will not:
\[\`TEXT\`\](LINK)

**Examples of this being broken:**
Here's a generated changelog being displayed on multiple different websites that render markdown.
- https://github.com/milkdrinkers/Enderchester/releases/tag/2.3.1
- https://modrinth.com/plugin/enderchester/version/2.3.1
- https://hangar.papermc.io/darksaid98/Enderchester/versions/2.3.1